### PR TITLE
Fix IAM role name created at firehose delivery stream creation

### DIFF
--- a/en/lab1/README.md
+++ b/en/lab1/README.md
@@ -51,7 +51,7 @@ In this section, you will create a Firehose stream that you can use to insert lo
 6. Enter **"workshop-log"** in **"Index"**. Amazon ES Index is equivalent to a table in DB in a simple analogy, but the log sent from this Firehose stream will be inserted into the index called workshop-log. If there is no Index on the Amazon ES in inserting, an Index is automatically created.
 7. Choose **[Every hour]** from the pull-down menu in **“Index rotation”**. With this setting, a new index is created every hour. The index name is also created with the date and time, such as "workshop-log-2020-04-01-09". This makes it possible to separate the data flowing in the stream by a certain date and time (the meaning of using this setting will be explained in more detail in Lab 3).
 8. In **"S3 backup"** below, click **[Create new]** button on the right of **"Back up S3 bucket"** to go to Create S3 bucket. In **"S3 bucket name"**, enter **"workshop-firehose-backup-YYYMMDD-YOURNAME"** (Replace YYYMMDD with today's date, for example, 20200701. And then, replace YOURNAME with your name like taroyamada. In this case, the bucket name will be “workshop-firehose-backup-20200701-taroyamada”). This bucket is used to store a backup of records that fail when inserting them from Firehose into Amazon ES.
-9. In **"Step 4: Configure settings"**, choose **[Cteate or update IAM role KInesisFirehoseServiceRole-XXX...]** and click **[Next]** button.
+9. In **"Step 4: Configure settings"**, choose **[Cteate or update IAM role KinesisFirehoseServiceRole-XXX...]** and click **[Next]** button.
 11. In **"Step 5: Review"**, review the settings you have entered in the above, and if there is no concern to them, click **[Create delivery stream]** to create a domain. It takes a few minutes to create the stream.
 
 ### Explanation
@@ -126,8 +126,8 @@ In this section, you will define a new write role with permission to add logs to
 
 ### Mapping Open Distro Roles with IAM Roles
 
-1. Go to **[Kinesis]** page from [Services] on the top left of the AWS Management Console.　From **"Kinesis Firehose Stream"** in the top right of the screen, choose **[workshop-firehose]** you have created in this Lab.　On the stream details screen, click the link **[workshop_firehose_delivery_role]** displayed in **"IAM role"**.
-2. In the IAM management console, click **"arn:aws:iam::123456789012:role/workshop_firehose_delivery_role"** to the right of **"Role ARN"**. (tthis value is different individually, so that make sure it on the screen and then copy it) This is the IAM role that manages permissions to AWS resources for Firehose.
+1. Go to **[Kinesis]** page from [Services] on the top left of the AWS Management Console.　From **"Kinesis Firehose Stream"** in the top right of the screen, choose **[workshop-firehose]** you have created in this Lab.　On the stream details screen, click the link **[KinesisFirehoseServiceRole-XXX...]** displayed in **"IAM role"**.
+2. In the IAM management console, click **"arn:aws:iam::123456789012:role/KinesisFirehoseServiceRole-XXX..."** to the right of **"Role ARN"**. (tthis value is different individually, so that make sure it on the screen and then copy it) This is the IAM role that manages permissions to AWS resources for Firehose.
 3. Go back to the management screen for Kibana. Next, click ![kibana_security](../images/kibana_security.png) icon on the left of the screen to open the security settings menu. Then, click **[Role Mappings]** under **"Permissions and Roles"** to go to the Role Mapping screen.
 4. Click + button on the right of the screen to open the new mapping screen.From the pull-down menu under **"Role:"** at the top of the screen, choose **[workshop_firehose_delivery_role]** you have created in the above. Then, click **[+ Add Backend Role]** button in **"Backend roles"**, and paste the string of Role ARN you have copied in the above.
 5. At last, click **[Submit]** to complete the mapping.

--- a/jp/lab1/README.md
+++ b/jp/lab1/README.md
@@ -51,7 +51,7 @@ Amazon ES における典型的な Easticsearch クラスターの構成は，�
 6. 次に **"Index"** で **"workshop-log"** と入力してください．Amazon ES の Index は，非常に噛み砕いた例えをするなら DB でいうところのテーブルに相当するものですが，この Firehose ストリームから送られたログは workshop-log という index に挿入されることになります．挿入時に Amazon ES 側に Index が存在しない場合には，自動で Index が作成されます
 7. また **"Index rotation"** でプルダウンから **[Every hour]** を選択してください．この設定を行うことで，新しい index が 1 時間ごとに作成されます．index 名も "workshop-log-2020-04-01-09" のように，後ろに日時をつけた形で作成されます．これにより，ストリームで流れてくるデータを一定の日時ごとに区切って取り扱うことができるようになります（この形をとる意味については，Lab 3 で詳しく説明します）
 8. その下の **"S3 backup"** で，**"Back up S3 bucket"** の右側 **[Create new]** ボタンを押して，S3 バケットの作成画面に進みます．**"S3 bucket name"** に，**"workshop-YYYYMMDD-YOURNAME"** と入力します（YYYYMMDD は 20200701 のように，今日の日付と置き換えてください．また YOURNAME は taroyamada のようにご自身の名前と置き換えてください．この場合バケット名は "workshop-20200701-taroyamada" となります）．このバケットは， Firehose から Amazon ES に挿入する際にエラーになったレコードを，バックアップとして格納するためのものです
-9. **"Step 4: Configure settings"** で，一番下の "Permission" において **[Cteate or update IAM role KInesisFirehoseServiceRole-XXX....]** を選択してから，**[Next]** を押します
+9. **"Step 4: Configure settings"** で，一番下の "Permission" において **[Cteate or update IAM role KinesisFirehoseServiceRole-XXX....]** を選択してから，**[Next]** を押します
 10. **"Step 5: Review"** で，これまでの設定内容を眺めて，特に問題がなければ画面右下の **[Create delivery stream]** を押してドメインを作成してください．ストリームの作成には数分程度かかります
 
 ### 解説
@@ -127,8 +127,8 @@ Amazon ES では，オープンソースの Elasticsearch ディストリビュ�
 
 ### Open Distro ロールと IAM ロールの紐付け
 
-1. AWS マネジメントコンソールの画面左上にある [サービス] から **[Kinesis]** のページを開いてください．画面右上の **"Kinesis Firehose 配信ストリーム"** から，先ほど作成した **[workshop-firehose]** を選択します．ストリームの詳細画面で，**"IAM role"** に表示されている **[workshop_firehose_delivery_role]** のリンクをクリックしてください
-2. IAM の管理画面で，**"ロール ARN"** の右にある **"arn:aws:iam::123456789012:role/workshop_firehose_delivery_role"** のような文字列をコピーします（この値は，各人で異なったものであるため，必ず画面上でコピーしてくだい）．これが Firehose の AWS リソースへのアクセス権限を管理する，IAM ロールと呼ばれるものです
+1. AWS マネジメントコンソールの画面左上にある [サービス] から **[Kinesis]** のページを開いてください．画面右上の **"Kinesis Firehose 配信ストリーム"** から，先ほど作成した **[workshop-firehose]** を選択します．ストリームの詳細画面で，**"IAM role"** に表示されている **[KinesisFirehoseServiceRole-XXX...]** のリンクをクリックしてください
+2. IAM の管理画面で，**"ロール ARN"** の右にある **"arn:aws:iam::123456789012:role/KinesisFirehoseServiceRole-XXX..."** のような文字列をコピーします（この値は，各人で異なったものであるため，必ず画面上でコピーしてくだい）．これが Firehose の AWS リソースへのアクセス権限を管理する，IAM ロールと呼ばれるものです
 3. 続いて Kibana の管理画面に戻ります．画面左側の![kibana_security](../images/kibana_security.png)マークをクリックして，セキュリティ設定のメニューを開いてください．**"Permissions and Roles"** の下にある **[Role Mappings]** をクリックして，ロール紐付け画面に進みます
 4.  画面右側の + ボタンをクリックして，新しい紐付けの作成画面を開きます．画面上部の **"Role:"** 下のプルダウンメニューから，先ほど作成した **[workshop_firehose_delivery_role]** を選択します．続いて **"Backend roles"** にある **[+ Add Backend Role]** ボタンを押して， 先ほどコピーしたロール ARN の文字列を貼り付けてください
 5. 最後に **[Submit]** を押して，紐付けを完了します


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 

Thank you so much for inspiring workshop!

  - Fix IAM role name created at firehose delivery stream creation. The correct role name is described [in step 9](https://github.com/aws-samples/amazon-elasticsearch-intro-workshop/tree/833608a/en/lab1#creating-a-firehose-stream).

![image](https://user-images.githubusercontent.com/3013078/94532290-a2777180-0278-11eb-87d7-0e5963f0e2fe.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
